### PR TITLE
Fixed css modules in prod build

### DIFF
--- a/packages/volto-blocks/news/5.bugfix
+++ b/packages/volto-blocks/news/5.bugfix
@@ -1,0 +1,1 @@
+Fixed css modules in prod build @pnicolli

--- a/packages/volto-blocks/razzle.extend.js
+++ b/packages/volto-blocks/razzle.extend.js
@@ -1,0 +1,56 @@
+const path = require('path');
+const makeLoaderFinder = require('razzle-dev-utils/makeLoaderFinder');
+const interpolateName = require('loader-utils').interpolateName;
+
+function normalizePath(file) {
+  return path.sep === '\\' ? file.replace(/\\/g, '/') : file;
+}
+
+// Custom function to not use 'loaderContext._module.matchResource' in hashing CSS class name.
+function getLocalIdent(loaderContext, localIdentName, localName, options) {
+  const relativeResourcePath = normalizePath(
+    path.relative(options.context, loaderContext.resourcePath),
+  );
+
+  // eslint-disable-next-line no-param-reassign
+  options.content = `${options.hashPrefix}${relativeResourcePath}\x00${localName}`;
+
+  return interpolateName(loaderContext, localIdentName, options);
+}
+
+module.exports = {
+  plugins: (plugs) => plugs,
+  modify: function modifyWebpackConfig(
+    defaultConfig,
+    { target, dev },
+    webpackObject,
+  ) {
+    const config = Object.assign({}, defaultConfig);
+
+    const cssLoaderFinder = makeLoaderFinder('css-loader');
+    const cssLoader = config.module.rules.find(cssLoaderFinder);
+
+    if (!dev && cssLoader) {
+      const loader = cssLoader.use.find(
+        (u) => typeof u !== 'string' && u.ident === 'razzle-css-loader',
+      );
+      if (loader) {
+        loader.options.modules.getLocalIdent = getLocalIdent;
+      }
+    }
+
+    const scssLoaderFinder = makeLoaderFinder('sass-loader');
+    const scssLoader = config.module.rules.find(scssLoaderFinder);
+
+    if (!dev && scssLoader) {
+      const loader = scssLoader.use.find(
+        (u) => typeof u !== 'string' && u.loader.match(/\/css-loader\//),
+      );
+      if (loader) {
+        loader.options.modules.getLocalIdent = getLocalIdent;
+      }
+    }
+
+    return config;
+  },
+};


### PR DESCRIPTION
Apply fixed from https://github.com/plone/volto/pull/5165 to css and scss files as well. The linked PR only applied these to less files.