### PR TITLE
fix: added clamp function to limit offset in special actions

### DIFF
--- a/packages/volto-slate-extras/news/6.bugfix
+++ b/packages/volto-slate-extras/news/6.bugfix
@@ -1,0 +1,1 @@
+Added clamp function to limit offset to avoid breaking when copying-pasting or reverting actions. @sabrina-bongiovanni

--- a/packages/volto-slate-extras/src/components/Widgets/TextEditorWidget/SimpleTextEditorWidget.jsx
+++ b/packages/volto-slate-extras/src/components/Widgets/TextEditorWidget/SimpleTextEditorWidget.jsx
@@ -81,10 +81,14 @@ const SimpleTextEditorWidget = (props) => {
   }
 
   function setCaret(el, offset) {
-    let sel = window.getSelection();
-    let range = document.createRange();
+    const sel = window.getSelection();
+    const range = document.createRange();
+
     if (el.childNodes?.length > 0) {
-      range.setStart(el.childNodes[0], offset);
+      const node = el.childNodes[0];
+      const maxOffset = node.textContent?.length ?? 0;
+      const clampedOffset = Math.min(offset, maxOffset);
+      range.setStart(node, clampedOffset);
       range.collapse(true);
       sel.removeAllRanges();
       sel.addRange(range);


### PR DESCRIPTION
Added clamp function that limits offset in setCaret function.
Editor sometimes throws error when 
- copying and pasting elements
- using cmd + z to revert action

Errors:
- Failed to execute 'setStart' on 'Range': The offset 12 is larger than the node's length (10)
- Failed to execute 'setStart' on 'Range': The offset 70 is larger than the node's length (11)

This fix ensures the offset never exceeds the available characters in the text node, avoiding IndexSizeError entirely 