### PR TITLE
fix: fix caret positioning in Slate headings and page title

### DIFF
--- a/packages/volto-slate-extras/news/8.bugfix
+++ b/packages/volto-slate-extras/news/8.bugfix
@@ -1,1 +1,1 @@
-Fixed caret positioning in Slate heading blocks (h2-h6) and page title widget. @Wagner3UB
+Fixed caret positioning in SimpleTextEditorWidget and render of heading blocks (h2-h6). @Wagner3UB @giuliaghisini

--- a/packages/volto-slate-extras/news/8.bugfix
+++ b/packages/volto-slate-extras/news/8.bugfix
@@ -1,0 +1,1 @@
+Fixed caret positioning in Slate heading blocks (h2-h6) and page title widget. @Wagner3UB

--- a/packages/volto-slate-extras/src/components/Widgets/TextEditorWidget/SimpleTextEditorWidget.jsx
+++ b/packages/volto-slate-extras/src/components/Widgets/TextEditorWidget/SimpleTextEditorWidget.jsx
@@ -117,7 +117,11 @@ const SimpleTextEditorWidget = (props) => {
   useEffect(() => {
     //inizializzazione del valore nel campo
     const _value = value ?? data[fieldName];
-    if (fieldRef.current && _value?.length > 0 && _value !== lastValueRef.current) {
+    if (
+      fieldRef.current &&
+      _value?.length > 0 &&
+      _value !== lastValueRef.current
+    ) {
       lastValueRef.current = _value;
       fieldRef.current.innerText = _value;
       if (selected) setDefaultCaretPosition();

--- a/packages/volto-slate-extras/src/components/Widgets/TextEditorWidget/SimpleTextEditorWidget.jsx
+++ b/packages/volto-slate-extras/src/components/Widgets/TextEditorWidget/SimpleTextEditorWidget.jsx
@@ -42,6 +42,7 @@ const SimpleTextEditorWidget = (props) => {
 
   const fieldRef = useRef();
   const caretPos = useRef();
+  const lastValueRef = useRef();
 
   const handleKey = (event) => {
     const { slate } = config.settings;
@@ -81,6 +82,7 @@ const SimpleTextEditorWidget = (props) => {
   }
 
   function setCaret(el, offset) {
+    if (!Number.isFinite(offset)) return;
     const sel = window.getSelection();
     const range = document.createRange();
 
@@ -101,8 +103,13 @@ const SimpleTextEditorWidget = (props) => {
 
   useEffect(() => {
     if (selected) {
-      fieldRef.current.focus();
-      setDefaultCaretPosition();
+      setTimeout(() => {
+        if (document.activeElement !== fieldRef.current) {
+          fieldRef.current.focus();
+        } else if (Number.isFinite(caretPos.current)) {
+          setDefaultCaretPosition();
+        }
+      }, 0);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selected]);
@@ -110,7 +117,8 @@ const SimpleTextEditorWidget = (props) => {
   useEffect(() => {
     //inizializzazione del valore nel campo
     const _value = value ?? data[fieldName];
-    if (fieldRef.current && _value?.length > 0) {
+    if (fieldRef.current && _value?.length > 0 && _value !== lastValueRef.current) {
+      lastValueRef.current = _value;
       fieldRef.current.innerText = _value;
       if (selected) setDefaultCaretPosition();
     }
@@ -166,6 +174,7 @@ const SimpleTextEditorWidget = (props) => {
           onChangeBlock(block, { ...data, ...retVal });
         }}
         onFocus={(e) => {
+          caretPos.current = getCaret(fieldRef.current);
           if (!selected) {
             selectThis();
           }

--- a/packages/volto-slate-extras/src/config/Slate/Headings/index.js
+++ b/packages/volto-slate-extras/src/config/Slate/Headings/index.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import HeadingsMenu from '@redturtle/volto-slate-extras/config/Slate/Headings/HeadingsMenu';
 import { insertToolbarButtons } from '@redturtle/volto-slate-extras/config/Slate/utils';
-import { renderLinkElement } from '@plone/volto-slate/editor/render';
 
 export default function install(config) {
   const { slate } = config.settings;
@@ -10,38 +9,25 @@ export default function install(config) {
     <HeadingsMenu {...props} title="Titolo" />
   );
 
-  //sovrascivo gli elements h2,h3,h4 per fare in modo che usino anche le classi di blocco (es allineamento)
-  slate.elements['h2'] = ({ attributes, children }) =>
-    renderLinkElement('h2')({
-      attributes,
-      children,
-      className: attributes.className,
-    });
-  slate.elements['h3'] = ({ attributes, children }) =>
-    renderLinkElement('h3')({
-      attributes,
-      children,
-      className: attributes.className,
-    });
-  slate.elements['h4'] = ({ attributes, children }) =>
-    renderLinkElement('h4')({
-      attributes,
-      children,
-      className: attributes.className,
-    });
-  //aggiungo gli elements h5, h6 perchè non previsti da volto
-  slate.elements['h5'] = ({ attributes, children }) =>
-    renderLinkElement('h5')({
-      attributes,
-      children,
-      className: attributes.className,
-    });
-  slate.elements['h6'] = ({ attributes, children }) =>
-    renderLinkElement('h6')({
-      attributes,
-      children,
-      className: attributes.className,
-    });
+  // Render headings as native tags so Slate attributes (ref, contentEditable, data-*) land on the
+  // actual DOM node. renderLinkElement applied tabIndex={0}, which broke caret positioning inside
+  // contentEditable headings. The block className (e.g. alignment) is preserved via {...attributes}.
+  slate.elements['h2'] = ({ attributes, children }) => (
+    <h2 {...attributes}>{children}</h2>
+  );
+  slate.elements['h3'] = ({ attributes, children }) => (
+    <h3 {...attributes}>{children}</h3>
+  );
+  slate.elements['h4'] = ({ attributes, children }) => (
+    <h4 {...attributes}>{children}</h4>
+  );
+  // h5, h6 are not provided by volto by default
+  slate.elements['h5'] = ({ attributes, children }) => (
+    <h5 {...attributes}>{children}</h5>
+  );
+  slate.elements['h6'] = ({ attributes, children }) => (
+    <h6 {...attributes}>{children}</h6>
+  );
 
   // rimuovo i bottoni di heading di volto
   slate.toolbarButtons = slate.toolbarButtons.filter(


### PR DESCRIPTION
## Summary

- Replace `renderLinkElement` with native heading tags (h2–h6) in `Headings/index.js` — `renderLinkElement` applied `tabIndex={0}` on contentEditable nodes, which broke caret positioning inside Slate heading blocks
- Fix caret positioning in `SimpleTextEditorWidget` — the wrapper div's `onClick` fired `selected=true` before the `onFocus` event, causing `setCaret(0)` to run before the browser placed the cursor at the click position; fixed with `setTimeout(0)` deferral and saving caret position on `onFocus`